### PR TITLE
feat: add a cross method for vec3 types

### DIFF
--- a/crates/vecn/Cargo.toml
+++ b/crates/vecn/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vecn"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Aaron Taner <mapkts@gmail.com>"]
 description = "A procedural macro that transforms user-defined structs into general vector types." 
 repository = "https://github.com/mapkts/vecn"

--- a/crates/vecn/src/lib.rs
+++ b/crates/vecn/src/lib.rs
@@ -1289,6 +1289,25 @@ fn expand(item: ItemStruct) -> std::result::Result<TokenStream, TokenStream> {
             )
         };
 
+        let impl_fn_cross = if fields_count == 3 {
+            // ONLY: fields_count == 3
+            let where_clause = if is_generic {
+                quote!(where #type_path: Copy + core::ops::Mul<Output=T> + core::ops::Sub<Output=T>)
+            } else {
+                quote!()
+            };
+            quote!(
+                /// Returns the cross product between `self` and `other`.
+                #[inline]
+                pub fn cross(self, other: Self) -> Self #where_clause {
+                    let ((x, y, z), (u, v, w)) = (self.into(), other.into());
+                    (y * w - z * v, z * u - x * w, x * v - y * u).into()
+                }
+            )
+        } else {
+            quote!()
+        };
+
         quote!(
            impl #generics #ident #generics #where_clause {
                #impl_consts
@@ -1308,6 +1327,7 @@ fn expand(item: ItemStruct) -> std::result::Result<TokenStream, TokenStream> {
                #impl_fn_abs
                #impl_fn_normalize
                #impl_fn_clamp
+               #impl_fn_cross
            }
         )
     };

--- a/tests/methods.rs
+++ b/tests/methods.rs
@@ -458,3 +458,30 @@ fn vec_fn_clamp() {
     let clamped = N4xu32::new(1, 4, 5, 8);
     assert_eq!(n4.clamp(min, max), clamped);
 }
+
+#[test]
+fn vec_cross() {
+    let t1 = T3::<i32>::new(2, 4, 4);
+    let t2 = T3::<i32>::new(1, 2, 3);
+
+    let n1 = N3::<i32>::new(2, 4, 4);
+    let n2 = N3::<i32>::new(1, 2, 3);
+
+    let cross1: T3<i32> = (4 * 3 - 4 * 2, 4 * 1 - 2 * 3, 2 * 2 - 4 * 1).into();
+    let cross2: N3<i32> = (4 * 3 - 4 * 2, 4 * 1 - 2 * 3, 2 * 2 - 4 * 1).into();
+
+    assert_eq!(t1.cross(t2), cross1);
+    assert_eq!(n1.cross(n2), cross2);
+
+    let t1 = T3xi32::new(2, 4, 4);
+    let t2 = T3xi32::new(1, 2, 3);
+
+    let n1 = N3xi32::new(2, 4, 4);
+    let n2 = N3xi32::new(1, 2, 3);
+
+    let cross1: T3xi32 = (4 * 3 - 4 * 2, 4 * 1 - 2 * 3, 2 * 2 - 4 * 1).into();
+    let cross2: N3xi32 = (4 * 3 - 4 * 2, 4 * 1 - 2 * 3, 2 * 2 - 4 * 1).into();
+
+    assert_eq!(t1.cross(t2), cross1);
+    assert_eq!(n1.cross(n2), cross2);
+}


### PR DESCRIPTION
Add a cross method to `Vec3` types, and bump crate version to v0.1.1