### PR TITLE
chore: bump version to v0.2.0

### DIFF
--- a/crates/vecn/Cargo.toml
+++ b/crates/vecn/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vecn"
-version = "0.1.3"
+version = "0.2.0"
 authors = ["Aaron Taner <mapkts@gmail.com>"]
 description = "A procedural macro that transforms user-defined structs into general vector types." 
 repository = "https://github.com/mapkts/vecn"


### PR DESCRIPTION
This will bump version to v0.2.0

Release-As: 0.2.0